### PR TITLE
Release gstreamer 1.18.5.20210908

### DIFF
--- a/gstreamer/gstreamer-devel.nuspec
+++ b/gstreamer/gstreamer-devel.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>gstreamer-devel</id>
     <title>GStreamer (Development)</title>
-    <version>1.18.4.20210725</version>
+    <version>1.18.5.20210908</version>
     <authors>GStreamer Team</authors>
     <owners>John McKernan (jmcker)</owners>
     <packageSourceUrl>https://github.com/jmcker/ChocolateyPackages/tree/main/gstreamer</packageSourceUrl>
@@ -15,7 +15,7 @@
     <tags>audio video recording streaming codec</tags>
     <licenseUrl>https://gitlab.freedesktop.org/gstreamer/gstreamer/blob/master/COPYING</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <releaseNotes>https://gstreamer.freedesktop.org/releases/1.18/#1.18.4</releaseNotes>
+    <releaseNotes>https://gstreamer.freedesktop.org/releases/1.18/#1.18.5</releaseNotes>
 
     <summary>A pipeline-based multimedia framework for recording, streaming, and editing.</summary>
     <description>

--- a/gstreamer/gstreamer-devel.nuspec
+++ b/gstreamer/gstreamer-devel.nuspec
@@ -31,7 +31,7 @@ This package performs a "Complete" install and may contain restricted codecs or 
     </description>
 
     <dependencies>
-      <dependency id="gstreamer" version="1.18.4.20210725" />
+      <dependency id="gstreamer" version="1.18.5.20210908" />
     </dependencies>
 
   </metadata>

--- a/gstreamer/gstreamer-mingw-devel.nuspec
+++ b/gstreamer/gstreamer-mingw-devel.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>gstreamer-mingw-devel</id>
     <title>GStreamer MinGW (Development)</title>
-    <version>1.18.4.20210725</version>
+    <version>1.18.5.20210908</version>
     <authors>GStreamer Team</authors>
     <owners>John McKernan (jmcker)</owners>
     <packageSourceUrl>https://github.com/jmcker/ChocolateyPackages/tree/main/gstreamer</packageSourceUrl>
@@ -15,7 +15,7 @@
     <tags>audio video recording streaming codec</tags>
     <licenseUrl>https://gitlab.freedesktop.org/gstreamer/gstreamer/blob/master/COPYING</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <releaseNotes>https://gstreamer.freedesktop.org/releases/1.18/#1.18.4</releaseNotes>
+    <releaseNotes>https://gstreamer.freedesktop.org/releases/1.18/#1.18.5</releaseNotes>
 
     <summary>A pipeline-based multimedia framework for recording, streaming, and editing.</summary>
     <description>
@@ -31,7 +31,7 @@ This package performs a "Complete" install and may contain restricted codecs or 
     </description>
 
     <dependencies>
-      <dependency id="gstreamer-mingw" version="1.18.4.20210725" />
+      <dependency id="gstreamer-mingw" version="1.18.5.20210908" />
     </dependencies>
 
   </metadata>

--- a/gstreamer/gstreamer-mingw.nuspec
+++ b/gstreamer/gstreamer-mingw.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>gstreamer-mingw</id>
     <title>GStreamer MinGW</title>
-    <version>1.18.4.20210725</version>
+    <version>1.18.5.20210908</version>
     <authors>GStreamer Team</authors>
     <owners>John McKernan (jmcker)</owners>
     <packageSourceUrl>https://github.com/jmcker/ChocolateyPackages/tree/main/gstreamer</packageSourceUrl>
@@ -15,7 +15,7 @@
     <tags>audio video recording streaming codec</tags>
     <licenseUrl>https://gitlab.freedesktop.org/gstreamer/gstreamer/blob/master/COPYING</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <releaseNotes>https://gstreamer.freedesktop.org/releases/1.18/#1.18.4</releaseNotes>
+    <releaseNotes>https://gstreamer.freedesktop.org/releases/1.18/#1.18.5</releaseNotes>
 
     <summary>A pipeline-based multimedia framework for recording, streaming, and editing.</summary>
     <description>

--- a/gstreamer/gstreamer.nuspec
+++ b/gstreamer/gstreamer.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>gstreamer</id>
     <title>GStreamer</title>
-    <version>1.18.4.20210725</version>
+    <version>1.18.5.20210908</version>
     <authors>GStreamer Team</authors>
     <owners>John McKernan (jmcker)</owners>
     <packageSourceUrl>https://github.com/jmcker/ChocolateyPackages/tree/main/gstreamer</packageSourceUrl>
@@ -15,7 +15,7 @@
     <tags>audio video recording streaming codec</tags>
     <licenseUrl>https://gitlab.freedesktop.org/gstreamer/gstreamer/blob/master/COPYING</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <releaseNotes>https://gstreamer.freedesktop.org/releases/1.18/#1.18.4</releaseNotes>
+    <releaseNotes>https://gstreamer.freedesktop.org/releases/1.18/#1.18.5</releaseNotes>
 
     <summary>A pipeline-based multimedia framework for recording, streaming, and editing.</summary>
     <description>


### PR DESCRIPTION
I'm not sure if you want the date to be the version's release date or the date of the modification.
I just used the version's release date.

I assume the checksums will update themselves automatically?

P.S. Merry Christmas! 